### PR TITLE
Backwards compatible endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,3 +15,7 @@ functions:
     - http:
         method: post
         cors: true
+    - http:
+        path: graphql
+        method: post
+        cors: true


### PR DESCRIPTION
Endpoint available in 2 routes to ensure compatibility with older version of the lib

```
Serverless: Routes for graphql:
Serverless: POST /
Serverless: POST /graphql
```